### PR TITLE
Dev

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+import { Command } from "commander";
+import { spawn } from "child_process";
+import path from "path";
+import fs from "fs";
+import chalk from "chalk";
+
+/**
+ * Original buildWorkspace function
+ */
+export async function buildWorkspace(args: { release?: boolean }) {
+  const projectRoot = process.cwd();
+  const srcDir = path.join(projectRoot, "src");
+  const pythonDir = path.join(projectRoot, "python");
+
+  if (!fs.existsSync(srcDir) && !fs.existsSync(pythonDir)) {
+    console.error(chalk.red("❌ No src/ or python/ directories found. Are you in a Genesys workspace?"));
+    process.exit(1);
+  }
+
+  const rosDistro = process.env.ROS_DISTRO || "humble";
+  if (!process.env.ROS_DISTRO) {
+    console.warn(chalk.yellow(`⚠️  ROS_DISTRO not set, defaulting to '${rosDistro}'`));
+  }
+
+  console.log(chalk.cyan(`\n🔧 Building Genesys workspace with ROS 2 '${rosDistro}'...\n`));
+
+  const rosSetup = `/opt/ros/${rosDistro}/setup.bash`;
+  let buildCmd = `source ${rosSetup} && colcon build --symlink-install --event-handlers console_direct+`;
+
+  if (args.release) {
+    console.log(chalk.green("⚡ Building in RELEASE mode (optimized)..."));
+    buildCmd += " --cmake-args -DCMAKE_BUILD_TYPE=Release";
+  } else {
+    console.log(chalk.green("🐛 Building in DEBUG mode (default)..."));
+  }
+
+  const colcon = spawn("bash", ["-c", buildCmd], { stdio: "inherit", cwd: projectRoot });
+
+  colcon.on("close", (code) => {
+    if (code === 0) {
+      console.log(chalk.green.bold("\n✅ Build completed successfully!\n"));
+      console.log(chalk.yellow("💡 Tip: Run `source install/setup.bash` before running nodes.\n"));
+    } else {
+      console.error(chalk.red("\n❌ Build failed. See errors above.\n"));
+      process.exit(code ?? 1);
+    }
+  });
+}
+
+/**
+ * Wrap in Commander command
+ */
+export const buildCommand = new Command("build")
+  .description("Build the Genesys workspace")
+  .option("-r, --release", "Build in release mode")
+  .action(async (options: { release?: boolean }) => {
+    await buildWorkspace({ release: options.release });
+  });

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,0 +1,32 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import path from "path";
+import fs from "fs";
+
+export const configCommand = new Command("config")
+  .description("Manage workspace configuration")
+  .argument("[key]", "Config key to view or edit")
+  .argument("[value]", "Value to set for the key (optional)")
+  .action((key?: string, value?: string) => {
+    const configFile = path.join(process.cwd(), "config", "config.json");
+
+    if (!fs.existsSync(configFile)) {
+      fs.mkdirSync(path.dirname(configFile), { recursive: true });
+      fs.writeFileSync(configFile, JSON.stringify({}, null, 2));
+    }
+
+    const config = JSON.parse(fs.readFileSync(configFile, "utf-8"));
+
+    if (!key) {
+      console.log(chalk.cyan("Current configuration:"), config);
+      return;
+    }
+
+    if (value === undefined) {
+      console.log(chalk.cyan(`${key}: ${config[key] ?? "undefined"}`));
+    } else {
+      config[key] = value;
+      fs.writeFileSync(configFile, JSON.stringify(config, null, 2));
+      console.log(chalk.green(`✅ Set ${key} = ${value}`));
+    }
+  });

--- a/src/commands/launch.ts
+++ b/src/commands/launch.ts
@@ -1,0 +1,45 @@
+// src/commands/launch.ts
+import { Command } from "commander";
+import chalk from "chalk";
+import path from "path";
+import fs from "fs";
+import { listLaunchFiles, runLaunchFile, normalizeLaunchFile } from "../utils/launchUtils.js";
+
+export const launchCommand = new Command("launch")
+  .description("Manage and run ROS 2 launch files in the Genesys workspace")
+  .argument("[file]", "Launch file name (no need to include suffix) or 'all' to run global genesys_launch.py")
+  .option("-l, --list", "List available launch files")
+  .option("-a, --args <args...>", "Pass arbitrary ROS 2 launch arguments (e.g., key:=value)")
+  .action((file: string | undefined, options?: { list?: boolean; args?: string[] }) => {
+    const workspaceRoot = process.cwd();
+    const launchDir = path.join(workspaceRoot, "launch");
+
+    if (!fs.existsSync(launchDir)) {
+      console.error(chalk.red("❌ No 'launch/' directory found. Did you scaffold any nodes?"));
+      process.exit(1);
+    }
+
+    const files = listLaunchFiles(launchDir);
+
+    // List mode
+    if (options?.list) {
+      if (files.length === 0) {
+        console.log(chalk.yellow("⚠️ No launch files found yet."));
+        return;
+      }
+      console.log(chalk.cyan("\n📂 Available launch files:\n"));
+      files.forEach((f) => console.log("  • " + chalk.green(f)));
+      console.log();
+      return;
+    }
+
+    // Determine launch file
+    let launchFile = "genesys_launch.py"; // default global launch
+    if (file && file.toLowerCase() !== "all") {
+      launchFile = normalizeLaunchFile(file);
+    }
+
+    // Run the launch file with optional args
+    const launchArgs = options?.args || [];
+    runLaunchFile(workspaceRoot, launchFile, launchArgs);
+  });

--- a/src/commands/make-node.ts
+++ b/src/commands/make-node.ts
@@ -8,7 +8,7 @@ import chalk from "chalk";
 export default function makeNode(program: Command) {
   program
     .command("make:node <name>")
-    .description("Generate a new robotics node (Python or C++) and register it")
+    .description("Generate a new ROS 2 package with a node (Python or C++) and register it")
     .action(async (name: string) => {
       const { lang } = await inquirer.prompt([
         {
@@ -20,14 +20,24 @@ export default function makeNode(program: Command) {
       ]);
 
       const baseDir = process.cwd();
+      const launchDir = path.join(baseDir, "launch");
+      if (!fs.existsSync(launchDir)) fs.mkdirSync(launchDir, { recursive: true });
 
-      // ---------- PYTHON ----------
+      // -------------------------------------------------
+      // PYTHON PACKAGE
+      // -------------------------------------------------
       if (lang === "Python") {
-        const dir = path.join(baseDir, "python", name);
-        if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+        const pkgDir = path.join(baseDir, "python", name);
+        const moduleDir = path.join(pkgDir, name);
 
-        const filePath = path.join(dir, "main.py");
-        const content = `import rclpy
+        fs.mkdirSync(moduleDir, { recursive: true });
+
+        // __init__.py for Python package
+        fs.writeFileSync(path.join(moduleDir, "__init__.py"), "");
+
+        // Node implementation
+        const nodePath = path.join(moduleDir, "main.py");
+        const nodeContent = `import rclpy
 from rclpy.node import Node
 
 class ${name}(Node):
@@ -45,11 +55,59 @@ def main(args=None):
 if __name__ == "__main__":
     main()
 `;
-        fs.writeFileSync(filePath, content);
+        fs.writeFileSync(nodePath, nodeContent);
 
-        // ---------- Launch file ----------
-        const launchDir = path.join(baseDir, "launch");
-        if (!fs.existsSync(launchDir)) fs.mkdirSync(launchDir, { recursive: true });
+        // setup.py
+        const setupPath = path.join(pkgDir, "setup.py");
+        const setupContent = `from setuptools import setup
+
+package_name = '${name}'
+
+setup(
+    name=package_name,
+    version='0.1.0',
+    packages=[package_name],
+    data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+    ],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    maintainer='dev',
+    maintainer_email='dev@example.com',
+    description='ROS 2 Python node package',
+    license='MIT',
+    tests_require=['pytest'],
+    entry_points={
+        'console_scripts': [
+            'main = ${name}.main:main',
+        ],
+    },
+)
+`;
+        fs.writeFileSync(setupPath, setupContent);
+
+        // package.xml
+        const pkgXmlPath = path.join(pkgDir, "package.xml");
+        const pkgXmlContent = `<package format="3">
+  <name>${name}</name>
+  <version>0.1.0</version>
+  <description>Python node package for ROS 2</description>
+  <maintainer email="dev@example.com">Developer</maintainer>
+  <license>MIT</license>
+
+  <exec_depend>rclpy</exec_depend>
+</package>
+`;
+        fs.writeFileSync(pkgXmlPath, pkgXmlContent);
+
+        // resource/<pkg>
+        const resDir = path.join(pkgDir, "resource");
+        fs.mkdirSync(resDir, { recursive: true });
+        fs.writeFileSync(path.join(resDir, name), "");
+
+        // Launch file
         const launchFile = path.join(launchDir, `${name}_launch.py`);
         const launchContent = `from launch import LaunchDescription
 from launch_ros.actions import Node
@@ -57,8 +115,8 @@ from launch_ros.actions import Node
 def generate_launch_description():
     return LaunchDescription([
         Node(
-            package='python',
-            executable='${name}',
+            package='${name}',
+            executable='main',
             name='${name.toLowerCase()}',
             output='screen'
         )
@@ -66,41 +124,23 @@ def generate_launch_description():
 `;
         fs.writeFileSync(launchFile, launchContent);
 
-        // ---------- Global genesys_launch.py ----------
-        const globalLaunch = path.join(launchDir, "genesys_launch.py");
-        let globalContent = "";
-        if (fs.existsSync(globalLaunch)) {
-          globalContent = fs.readFileSync(globalLaunch, "utf8");
-        } else {
-          globalContent = "from launch import LaunchDescription\n\n";
-          globalContent += "def generate_launch_description():\n";
-          globalContent += "    ld = LaunchDescription()\n";
-          globalContent += "    return ld\n";
-        }
-        if (!globalContent.includes(`${name}_launch`)) {
-          // Insert import and append node
-          globalContent = `from .${name}_launch import generate_launch_description as ${name}_launch\n` +
-            globalContent.replace(
-              "return ld",
-              `ld.add_action(${name}_launch())\n    return ld`
-            );
-          fs.writeFileSync(globalLaunch, globalContent);
-          console.log(chalk.yellowBright(`📦 Registered Python node '${name}' in genesys_launch.py`));
-        }
+        registerInGlobalLaunch(launchDir, name);
 
-        console.log(chalk.greenBright("✅ Python node created at: ") + chalk.cyan(filePath));
-        console.log(chalk.greenBright("📄 Launch file created at: ") + chalk.cyan(launchFile));
+        console.log(chalk.greenBright("✅ Python package created at: ") + chalk.cyan(pkgDir));
+        console.log(chalk.magenta(`👉 Build with: colcon build --packages-select ${name}`));
+        console.log(chalk.magenta(`👉 Run with: ros2 launch ${name} ${name}_launch.py`));
       }
 
-      // ---------- C++ ----------
+      // -------------------------------------------------
+      // C++ PACKAGE
+      // -------------------------------------------------
       if (lang === "C++") {
-        const dir = path.join(baseDir, "src", name);
-        if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+        const pkgDir = path.join(baseDir, "src", name);
+        fs.mkdirSync(pkgDir, { recursive: true });
 
-        const filePath = path.join(dir, "main.cpp");
-        const cmakePath = path.join(dir, "CMakeLists.txt");
-
-        const content = `#include "rclcpp/rclcpp.hpp"
+        // Node implementation
+        const nodePath = path.join(pkgDir, "main.cpp");
+        const nodeContent = `#include "rclcpp/rclcpp.hpp"
 
 class ${name} : public rclcpp::Node {
 public:
@@ -116,39 +156,44 @@ int main(int argc, char **argv) {
     return 0;
 }
 `;
+        fs.writeFileSync(nodePath, nodeContent);
+
+        // CMakeLists.txt
+        const cmakePath = path.join(pkgDir, "CMakeLists.txt");
         const cmakeContent = `cmake_minimum_required(VERSION 3.8)
 project(${name})
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 
-add_executable(${name} main.cpp)
-ament_target_dependencies(${name} rclcpp)
+add_executable(main main.cpp)
+ament_target_dependencies(main rclcpp)
 
 install(TARGETS
-  ${name}
-  DESTINATION lib/${name}
+  main
+  DESTINATION lib/\${PROJECT_NAME}
 )
 
 ament_package()
 `;
-        fs.writeFileSync(filePath, content);
         fs.writeFileSync(cmakePath, cmakeContent);
 
-        // auto-register in root CMakeLists.txt
-        const rootCmake = path.join(baseDir, "src", "CMakeLists.txt");
-        if (fs.existsSync(rootCmake)) {
-          let rootContent = fs.readFileSync(rootCmake, "utf8");
-          if (!rootContent.includes(`add_subdirectory(${name})`)) {
-            rootContent += `\nadd_subdirectory(${name})\n`;
-            fs.writeFileSync(rootCmake, rootContent);
-            console.log(chalk.yellowBright(`📦 Registered C++ node '${name}' in root CMakeLists.txt`));
-          }
-        }
+        // package.xml
+        const pkgXmlPath = path.join(pkgDir, "package.xml");
+        const pkgXmlContent = `<package format="3">
+  <name>${name}</name>
+  <version>0.1.0</version>
+  <description>C++ node package for ROS 2</description>
+  <maintainer email="dev@example.com">Developer</maintainer>
+  <license>MIT</license>
 
-        // ---------- Launch file ----------
-        const launchDir = path.join(baseDir, "launch");
-        if (!fs.existsSync(launchDir)) fs.mkdirSync(launchDir, { recursive: true });
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>rclcpp</depend>
+</package>
+`;
+        fs.writeFileSync(pkgXmlPath, pkgXmlContent);
+
+        // Launch file
         const launchFile = path.join(launchDir, `${name}_launch.py`);
         const launchContent = `from launch import LaunchDescription
 from launch_ros.actions import Node
@@ -157,7 +202,7 @@ def generate_launch_description():
     return LaunchDescription([
         Node(
             package='${name}',
-            executable='${name}',
+            executable='main',
             name='${name.toLowerCase()}',
             output='screen'
         )
@@ -165,8 +210,42 @@ def generate_launch_description():
 `;
         fs.writeFileSync(launchFile, launchContent);
 
-        console.log(chalk.greenBright("✅ C++ node created at: ") + chalk.cyan(filePath));
-        console.log(chalk.greenBright("📄 Launch file created at: ") + chalk.cyan(launchFile));
+        registerInGlobalLaunch(launchDir, name);
+
+        console.log(chalk.greenBright("✅ C++ package created at: ") + chalk.cyan(pkgDir));
+        console.log(chalk.magenta(`👉 Build with: colcon build --packages-select ${name}`));
+        console.log(chalk.magenta(`👉 Run with: ros2 launch ${name} ${name}_launch.py`));
       }
     });
+}
+
+/**
+ * Auto-registers new launch files inside a global genesys_launch.py
+ */
+function registerInGlobalLaunch(launchDir: string, nodeName: string) {
+  const globalLaunch = path.join(launchDir, "genesys_launch.py");
+  let globalContent = "";
+
+  if (!fs.existsSync(globalLaunch)) {
+    globalContent = `from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+import os
+
+def generate_launch_description():
+    ld = LaunchDescription()
+    return ld
+`;
+  } else {
+    globalContent = fs.readFileSync(globalLaunch, "utf8");
+  }
+
+  if (!globalContent.includes(`${nodeName}_launch.py`)) {
+    const includeStmt = `    ld.add_action(IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(os.path.join(os.path.dirname(__file__), "${nodeName}_launch.py"))
+    ))\n    `;
+    globalContent = globalContent.replace("return ld", includeStmt + "return ld");
+    fs.writeFileSync(globalLaunch, globalContent);
+    console.log(chalk.yellowBright(`📦 Registered node '${nodeName}' in genesys_launch.py`));
+  }
 }

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -1,44 +1,90 @@
+// src/commands/new.ts
 import { Command } from "commander";
 import fs from "fs";
 import path from "path";
+import { execSync } from "child_process";
 
-export default function newProject(program: Command) {
-  program
-    .command("new <name>")
-    .description("Create a new GENESYS robotics project")
-    .action((name) => {
-      const projectRoot = path.resolve(process.cwd(), name);
+// Run shell command safely
+function runCmd(cmd: string): string | null {
+  try {
+    return execSync(cmd, { stdio: ["pipe", "pipe", "ignore"] })
+      .toString()
+      .trim();
+  } catch {
+    return null;
+  }
+}
 
-      if (fs.existsSync(projectRoot)) {
-        console.error(`❌ Project folder '${name}' already exists.`);
-        process.exit(1);
-      }
+// Detect ROS version
+function detectROS(): "ros2" | "ros1" | "none" {
+  const ros2 = runCmd("ros2 --version");
+  if (ros2) return "ros2";
+  const ros1 = runCmd("rosversion -d");
+  if (ros1) return "ros1";
+  return "none";
+}
 
-      // Base structure
-      const dirs = [
-        "app",          // high-level logic/controllers
-        "src",          // C++ ROS 2 nodes
-        "python",       // Python ROS 2 nodes
-        "interfaces",   // shared msgs/srvs/actions
-        "config",       // YAML configs
-        "launch",       // launch files
-        "sim",          // URDF, Gazebo worlds
-        "packages",     // installable modules
-        "tests",        // unit/integration tests
-        "scripts",      // helper scripts
-        "tools",        // dev utilities
-        ".devcontainer" // VS Code Dev Container config
-      ];
+// Check dependencies list
+function checkDependencies() {
+  console.log("🔍 Checking dependencies...");
 
-      fs.mkdirSync(projectRoot, { recursive: true });
-      dirs.forEach((dir) => {
-        fs.mkdirSync(path.join(projectRoot, dir), { recursive: true });
-      });
+  const ros = detectROS();
+  if (ros === "none") {
+    console.error("❌ ROS not detected. Please install ROS 2 (recommended).");
+    process.exit(1);
+  }
 
-      // --- README ---
-      fs.writeFileSync(
-        path.join(projectRoot, "README.md"),
-        `# ${name}
+  console.log(`✅ Detected ${ros.toUpperCase()}`);
+
+  const deps = [
+    { cmd: "python3 --version", name: "Python 3" },
+    { cmd: "cmake --version", name: "CMake" },
+    { cmd: "colcon --version", name: "colcon build" },
+  ];
+
+  let allDepsOk = true;
+  deps.forEach((dep) => {
+    if (!runCmd(dep.cmd)) {
+      console.error(`❌ Missing dependency: ${dep.name}`);
+      allDepsOk = false;
+    }
+  });
+
+  if (!allDepsOk) {
+    console.error(
+      "\n⚠️ One or more dependencies are missing. Please install them before creating a GENESYS project."
+    );
+    process.exit(1);
+  }
+
+  console.log("✅ All dependencies OK!\n");
+}
+
+// Create base project structure
+function createStructure(projectRoot: string, name: string) {
+  const dirs = [
+    "app",
+    "src",
+    "python",
+    "interfaces",
+    "config",
+    "launch",
+    "sim",
+    "packages",
+    "tests",
+    "scripts",
+    "tools",
+  ];
+
+  fs.mkdirSync(projectRoot, { recursive: true });
+  dirs.forEach((dir) => {
+    fs.mkdirSync(path.join(projectRoot, dir), { recursive: true });
+  });
+
+  // README
+  fs.writeFileSync(
+    path.join(projectRoot, "README.md"),
+    `# ${name}
 
 A **GENESYS** robotics project.
 
@@ -54,36 +100,35 @@ A **GENESYS** robotics project.
 - \`tests/\`: testing
 - \`scripts/\`: helper scripts
 - \`tools/\`: dev utilities
-- \`.devcontainer/\`: VS Code Dev Container setup
 
 Generated with **GENESYS CLI** 🚀
 `
-      );
+  );
 
-      // --- Robot config ---
-      fs.writeFileSync(
-        path.join(projectRoot, "config", "robot.yaml"),
-        `# Robot configuration
+  // Robot config
+  fs.writeFileSync(
+    path.join(projectRoot, "config", "robot.yaml"),
+    `# Robot configuration
 name: ${name}
 sensors: {}
 motors: {}
 `
-      );
+  );
 
-      // --- Launch stub ---
-      fs.writeFileSync(
-        path.join(projectRoot, "launch", `${name}_launch.py`),
-        `from launch import LaunchDescription
+  // Launch stub
+  fs.writeFileSync(
+    path.join(projectRoot, "launch", `${name}_launch.py`),
+    `from launch import LaunchDescription
 
 def generate_launch_description():
     return LaunchDescription([])
 `
-      );
+  );
 
-      // --- ROS package.xml ---
-      fs.writeFileSync(
-        path.join(projectRoot, "package.xml"),
-        `<package format="3">
+  // package.xml
+  fs.writeFileSync(
+    path.join(projectRoot, "package.xml"),
+    `<package format="3">
   <name>${name}</name>
   <version>0.1.0</version>
   <description>GENESYS robotics project</description>
@@ -92,75 +137,53 @@ def generate_launch_description():
   <buildtool_depend>ament_cmake</buildtool_depend>
 </package>
 `
-      );
+  );
 
-      // --- Devcontainer config ---
-      fs.writeFileSync(
-        path.join(projectRoot, ".devcontainer", "devcontainer.json"),
-        `{
-  "name": "${name}-dev",
-  "dockerFile": "../Dockerfile",
-  "context": "..",
-  "workspaceFolder": "/workspace",
-  "customizations": {
-    "vscode": {
-      "extensions": [
-        "ms-iot.vscode-ros",
-        "ms-python.python",
-        "ms-vscode.cpptools",
-        "ms-azuretools.vscode-docker"
-      ]
-    }
-  },
-  "remoteUser": "root"
+  // Workspace-level CMakeLists.txt (so colcon has an entry)
+  fs.writeFileSync(
+    path.join(projectRoot, "src", "CMakeLists.txt"),
+    `cmake_minimum_required(VERSION 3.8)
+project(${name}_workspace)
+
+# Add subdirectories for nodes as they are created
+`
+  );
+
+  // Drop COLCON_IGNORE into non-package dirs
+  const ignoreDirs = [
+    "app",
+    "python",
+    "interfaces",
+    "config",
+    "launch",
+    "sim",
+    "packages",
+    "tests",
+    "scripts",
+    "tools",
+  ];
+  ignoreDirs.forEach((dir) => {
+    fs.writeFileSync(path.join(projectRoot, dir, "COLCON_IGNORE"), "");
+  });
 }
-`
-      );
 
-      // --- Dockerfile ---
-      fs.writeFileSync(
-        path.join(projectRoot, "Dockerfile"),
-        `# GENESYS Robotics Project Dockerfile
-FROM ros:humble
+export default function newProject(program: Command) {
+  program
+    .command("new <name>")
+    .description("Create a new GENESYS robotics project")
+    .action((name) => {
+      checkDependencies();
 
-# Install common tools
-RUN apt-get update && apt-get install -y \\
-    python3-pip \\
-    build-essential \\
-    ros-humble-ros-base \\
-    && rm -rf /var/lib/apt/lists/*
+      const projectRoot = path.resolve(process.cwd(), name);
 
-# Workspace setup
-WORKDIR /workspace
-COPY . /workspace
+      if (fs.existsSync(projectRoot)) {
+        console.error(`❌ Project folder '${name}' already exists.`);
+        process.exit(1);
+      }
 
-# Install Python deps if requirements.txt exists
-RUN if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
-
-# Build ROS 2 workspace
-RUN . /opt/ros/humble/setup.sh && colcon build || true
-
-CMD ["/bin/bash"]
-`
-      );
-
-      // --- docker-compose.yml ---
-      fs.writeFileSync(
-        path.join(projectRoot, "docker-compose.yml"),
-        `version: "3.9"
-services:
-  app:
-    build: .
-    container_name: ${name}_container
-    volumes:
-      - .:/workspace
-    working_dir: /workspace
-    tty: true
-    stdin_open: true
-`
-      );
+      createStructure(projectRoot, name);
 
       console.log(`✅ New GENESYS project '${name}' created at ${projectRoot}`);
-      console.log(`👉 Next: cd ${name} && genesys make:node MyNode --lang python`);
+      console.log(`👉 Next: cd ${name} && genesys make:node MyNode`);
     });
 }

--- a/src/commands/package.ts
+++ b/src/commands/package.ts
@@ -1,0 +1,23 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import path from "path";
+import fs from "fs";
+
+export const packageCommand = new Command("package")
+  .description("Scaffold a new Genesys package")
+  .argument("<name>", "Package name")
+  .option("-l, --language <lang>", "Language: cpp or python", "cpp")
+  .action((name: string, options: { language?: string }) => {
+    const workspaceRoot = process.cwd();
+    const pkgDir = path.join(workspaceRoot, options.language === "python" ? "python" : "src", name);
+
+    if (fs.existsSync(pkgDir)) {
+      console.error(chalk.red(`❌ Package ${name} already exists.`));
+      process.exit(1);
+    }
+
+    fs.mkdirSync(pkgDir, { recursive: true });
+
+    console.log(chalk.green(`✅ Created ${options.language} package: ${name}`));
+    // Could add basic structure scaffolding: src/scripts, package.xml/setup.py
+  });

--- a/src/commands/record.ts
+++ b/src/commands/record.ts
@@ -1,0 +1,58 @@
+import { Command } from "commander";
+import { spawn } from "child_process";
+import path from "path";
+import fs from "fs";
+import chalk from "chalk";
+
+export const recordCommand = new Command("record")
+  .description("Record ROS 2 topics to a bag file (records all topics by default)")
+  .argument("[topics...]", "List of ROS topics to record")
+  .option("-o, --output <file>", "Output bag file name", "recording.bag")
+  .option("-a, --args <args...>", "Additional ros2 bag record arguments")
+  .action((topics: string[] | undefined, options?: { output?: string; args?: string[] }) => {
+    const workspaceRoot = process.cwd();
+    const srcDir = path.join(workspaceRoot, "src");
+    const pythonDir = path.join(workspaceRoot, "python");
+
+    // Validate workspace
+    if (!fs.existsSync(srcDir) && !fs.existsSync(pythonDir)) {
+      console.error(
+        chalk.red("❌ No src/ or python/ directories found. Are you in a Genesys workspace?")
+      );
+      process.exit(1);
+    }
+
+    // Record all topics by default if none specified
+    const topicsToRecord = topics && topics.length > 0 ? topics : ["-a"];
+
+    const rosDistro = process.env.ROS_DISTRO || "humble";
+    if (!process.env.ROS_DISTRO) {
+      console.warn(chalk.yellow(`⚠️ ROS_DISTRO not set, defaulting to '${rosDistro}'`));
+    }
+
+    console.log(
+      chalk.cyan(
+        `🛑 Recording topics: ${
+          topicsToRecord.includes("-a") ? "ALL TOPICS" : topicsToRecord.join(", ")
+        }`
+      )
+    );
+    console.log(chalk.yellow(`Output bag file: ${options?.output}`));
+
+    const rosSetup = `/opt/ros/${rosDistro}/setup.bash`;
+    const extraArgs = options?.args ? options.args.join(" ") : "";
+    const cmd = `source ${rosSetup} && ros2 bag record -o ${options?.output} ${topicsToRecord.join(
+      " "
+    )} ${extraArgs}`;
+
+    const proc = spawn("bash", ["-c", cmd], { stdio: "inherit" });
+
+    proc.on("close", (code) => {
+      console.log(chalk.green(`✅ Recording stopped with exit code ${code}`));
+    });
+
+    // Forward SIGINT to child process
+    process.on("SIGINT", () => {
+      proc.kill("SIGINT");
+    });
+  });

--- a/src/commands/replay.ts
+++ b/src/commands/replay.ts
@@ -1,0 +1,61 @@
+import { Command } from "commander";
+import { spawn } from "child_process";
+import fs from "fs";
+import path from "path";
+import chalk from "chalk";
+
+export const replayCommand = new Command("replay")
+  .description("Replay a ROS 2 bag file")
+  .argument("[file]", "Bag file to replay (defaults to the latest .bag in workspace)")
+  .option("-a, --args <args...>", "Additional ros2 bag play arguments")
+  .action((file: string | undefined, options?: { args?: string[] }) => {
+    const workspaceDir = process.cwd();
+
+    let bagFile: string;
+
+    if (file) {
+      bagFile = path.resolve(workspaceDir, file);
+      if (!fs.existsSync(bagFile)) {
+        console.error(chalk.red(`❌ Bag file not found: ${bagFile}`));
+        process.exit(1);
+      }
+    } else {
+      // Find latest .bag file in workspace
+      const bagFiles = fs.readdirSync(workspaceDir)
+        .filter((f) => f.endsWith(".bag"))
+        .map((f) => path.join(workspaceDir, f));
+
+      if (bagFiles.length === 0) {
+        console.error(chalk.red("❌ No .bag files found in the workspace."));
+        process.exit(1);
+      }
+
+      // Sort by modified time descending
+      bagFiles.sort((a, b) => fs.statSync(b).mtime.getTime() - fs.statSync(a).mtime.getTime());
+      bagFile = bagFiles[0];
+      console.log(chalk.yellow(`⚡ No bag file specified, defaulting to latest: ${path.basename(bagFile)}`));
+    }
+
+    const rosDistro = process.env.ROS_DISTRO || "humble";
+    if (!process.env.ROS_DISTRO) {
+      console.warn(chalk.yellow(`⚠️ ROS_DISTRO not set, defaulting to '${rosDistro}'`));
+    }
+
+    const rosSetup = `/opt/ros/${rosDistro}/setup.bash`;
+    const extraArgs = options?.args ? options.args.join(" ") : "";
+
+    console.log(chalk.cyan(`▶️ Replaying bag file: ${bagFile}`));
+    if (extraArgs) console.log(chalk.yellow(`📄 With extra arguments: ${extraArgs}`));
+
+    const cmd = `source ${rosSetup} && ros2 bag play ${bagFile} ${extraArgs}`;
+    const proc = spawn("bash", ["-c", cmd], { stdio: "inherit" });
+
+    proc.on("close", (code) => {
+      console.log(chalk.green(`✅ Replay finished with exit code ${code}`));
+    });
+
+    // Forward SIGINT to child process
+    process.on("SIGINT", () => {
+      proc.kill("SIGINT");
+    });
+  });

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,0 +1,51 @@
+// src/commands/run.ts
+import { Command } from "commander";
+import chalk from "chalk";
+import path from "path";
+import fs from "fs";
+import { normalizeLaunchFile, runLaunchFile, listLaunchFiles } from "../utils/launchUtils.js";
+
+export const runCommand = new Command("run")
+  .description("Run a specific node or all nodes in the Genesys workspace")
+  .argument("[nodeName]", "Name of the node to run, or 'all' for all nodes")
+  .option("-l, --list", "List available launch files")
+  .option("-a, --args <args...>", "Pass arbitrary ROS 2 launch arguments (e.g., key:=value)")
+  .action(
+    (
+      nodeName: string | undefined,
+      options: { list?: boolean; args?: string[] }
+    ) => {
+      const workspaceRoot = process.cwd();
+      const launchDir = path.join(workspaceRoot, "launch");
+
+      if (!fs.existsSync(launchDir)) {
+        console.error(
+          chalk.red("❌ No 'launch/' directory found. Did you scaffold any nodes?")
+        );
+        process.exit(1);
+      }
+
+      // List available launch files
+      if (options.list) {
+        const files = listLaunchFiles(launchDir);
+        if (files.length === 0) {
+          console.log(chalk.yellow("⚠️ No launch files found yet."));
+          return;
+        }
+        console.log(chalk.cyan("\n📂 Available launch files:\n"));
+        files.forEach((f) => console.log("  • " + chalk.green(f)));
+        console.log();
+        return;
+      }
+
+      // Determine launch file
+      let launchFile = "genesys_launch.py"; // default global launch
+      if (nodeName && nodeName.toLowerCase() !== "all") {
+        launchFile = normalizeLaunchFile(nodeName);
+      }
+
+      // Run the launch file with optional args
+      const launchArgs = options.args || [];
+      runLaunchFile(workspaceRoot, launchFile, launchArgs);
+    }
+  );

--- a/src/commands/sim.ts
+++ b/src/commands/sim.ts
@@ -1,0 +1,59 @@
+// src/commands/sim.ts
+import { Command } from "commander";
+import chalk from "chalk";
+import path from "path";
+import fs from "fs";
+import { listLaunchFiles, normalizeLaunchFile, runLaunchFile } from "../utils/launchUtils.js";
+
+export const simCommand = new Command("sim")
+  .description("Launch a simulation environment (Gazebo) in the Genesys workspace")
+  .argument("[file]", "Simulation launch file name (without suffix) or 'all' for default sim")
+  .option("-l, --list", "List available simulation launch files")
+  .option("-w, --world <world>", "Specify a Gazebo world file to launch")
+  .option("-a, --args <args...>", "Pass arbitrary ROS 2 launch arguments")
+  .action(
+    (
+      file: string | undefined,
+      options: { list?: boolean; world?: string; args?: string[] }
+    ) => {
+      const workspaceRoot = process.cwd();
+      const launchDir = path.join(workspaceRoot, "launch");
+
+      if (!fs.existsSync(launchDir)) {
+        console.error(chalk.red("❌ No 'launch/' directory found. Did you scaffold any nodes?"));
+        process.exit(1);
+      }
+
+      // List mode
+      if (options.list) {
+        const files = listLaunchFiles(launchDir);
+        if (files.length === 0) {
+          console.log(chalk.yellow("⚠️ No launch files found."));
+          return;
+        }
+        console.log(chalk.cyan("\n📂 Available simulation launch files:\n"));
+        files.forEach((f) => console.log("  • " + chalk.green(f)));
+        console.log();
+        return;
+      }
+
+      // Determine launch file
+      let launchFile = "genesys_launch.py"; // default global launch
+      if (file && file.toLowerCase() !== "all") {
+        launchFile = normalizeLaunchFile(file);
+      }
+
+      // Prepare launch arguments
+      const launchArgs: string[] = [];
+      if (options.world) {
+        console.log(chalk.yellow(`🌎 Launching with world: ${options.world}`));
+        launchArgs.push(`world:=${options.world}`);
+      }
+      if (options.args) {
+        launchArgs.push(...options.args);
+      }
+
+      // Run the launch file with optional args
+      runLaunchFile(workspaceRoot, launchFile, launchArgs);
+    }
+  );

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -1,0 +1,113 @@
+import { Command } from "commander";
+import { spawn } from "child_process";
+import chalk from "chalk";
+import path from "path";
+import fs from "fs";
+
+export const testCommand = new Command("test")
+  .description("Run unit or integration tests for Python and C++ packages")
+  .option("-a, --args <args...>", "Additional pytest arguments")
+  .action(async (options?: { args?: string[] }) => {
+    const workspaceRoot = process.cwd();
+    const srcDir = path.join(workspaceRoot, "src");
+    const pythonDir = path.join(workspaceRoot, "python");
+
+    // Validate workspace
+    if (!fs.existsSync(srcDir) && !fs.existsSync(pythonDir)) {
+      console.error(
+        chalk.red("❌ No src/ or python/ directories found. Are you in a Genesys workspace?")
+      );
+      process.exit(1);
+    }
+
+    console.log(chalk.cyan("🧪 Running tests in Genesys workspace..."));
+
+    const testPromises: Promise<number>[] = [];
+
+    // ----------- Top-Level Tests -----------
+    const topLevelTestDir = path.join(workspaceRoot, "tests");
+    if (fs.existsSync(topLevelTestDir)) {
+      const pytestArgs = options?.args ? options.args.join(" ") : "";
+      const cmd = `pytest ${pytestArgs}`;
+      console.log(chalk.cyan("🐍 Running top-level Python tests in /tests"));
+      testPromises.push(
+        new Promise((resolve) => {
+          const proc = spawn("bash", ["-c", cmd], { cwd: topLevelTestDir, stdio: "inherit" });
+          proc.on("close", (code) => resolve(code ?? 1));
+        })
+      );
+    }
+
+    // ----------- Python Packages -----------
+    if (fs.existsSync(pythonDir)) {
+      const pythonPkgs = fs.readdirSync(pythonDir).filter((pkg) => {
+        const pkgPath = path.join(pythonDir, pkg);
+        return fs.existsSync(pkgPath) && fs.existsSync(path.join(pkgPath, "setup.py"));
+      });
+
+      for (const pkg of pythonPkgs) {
+        const pkgPath = path.join(pythonDir, pkg);
+        const testDir = path.join(pkgPath, "tests");
+
+        if (!fs.existsSync(testDir)) {
+          console.log(chalk.yellow(`⚠️ No tests/ directory for Python package: ${pkg}`));
+          continue;
+        }
+
+        const pytestArgs = options?.args ? options.args.join(" ") : "";
+        const cmd = `pytest ${pytestArgs}`;
+
+        console.log(chalk.cyan(`🐍 Running Python tests for package: ${pkg}`));
+        testPromises.push(
+          new Promise((resolve) => {
+            const proc = spawn("bash", ["-c", cmd], { cwd: testDir, stdio: "inherit" });
+            proc.on("close", (code) => resolve(code ?? 1));
+          })
+        );
+      }
+    }
+
+    // ----------- C++ Packages -----------
+    if (fs.existsSync(srcDir)) {
+      const cppPkgs = fs.readdirSync(srcDir).filter((pkg) => {
+        const pkgPath = path.join(srcDir, pkg);
+        return fs.existsSync(pkgPath) && fs.existsSync(path.join(pkgPath, "package.xml"));
+      });
+
+      for (const pkg of cppPkgs) {
+        const pkgPath = path.join(srcDir, pkg);
+        const testDir = path.join(pkgPath, "tests");
+
+        if (!fs.existsSync(testDir)) {
+          console.log(chalk.yellow(`⚠️ No tests/ directory for C++ package: ${pkg}`));
+          continue;
+        }
+
+        console.log(chalk.cyan(`💻 Running C++ tests for package: ${pkg}`));
+        const cmd = `colcon test --packages-select ${pkg}`;
+        testPromises.push(
+          new Promise((resolve) => {
+            const proc = spawn("bash", ["-c", cmd], { cwd: workspaceRoot, stdio: "inherit" });
+            proc.on("close", (code) => resolve(code ?? 1));
+          })
+        );
+      }
+    }
+
+    if (testPromises.length === 0) {
+      console.log(chalk.yellow("⚠️ No tests found in workspace."));
+      process.exit(0);
+    }
+
+    // Wait for all tests
+    const results = await Promise.all(testPromises);
+    const failed = results.filter((code) => code !== 0).length;
+
+    if (failed === 0) {
+      console.log(chalk.green("✅ All tests passed!"));
+      process.exit(0);
+    } else {
+      console.error(chalk.red(`❌ ${failed} test(s) failed.`));
+      process.exit(1);
+    }
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,26 +1,46 @@
 #!/usr/bin/env node
-console.log("GENESYS CLI is working!");
-
-import { Command } from 'commander'
-import makeNode from './commands/make-node.js'
-import process from 'process';
-import newProject from './commands/new.js';
+import { Command } from "commander";
+import process from "process";
+import makeNode from "./commands/make-node.js";
+import newProject from "./commands/new.js";
+import { launchCommand } from "./commands/launch.js";
+import { runCommand } from "./commands/run.js";
+import { buildCommand } from "./commands/build.js";
+import { simCommand } from "./commands/sim.js";
+import { testCommand } from "./commands/test.js";
+import { configCommand } from "./commands/config.js";
+import { recordCommand } from "./commands/record.js";
+import { replayCommand } from "./commands/replay.js";
+import { packageCommand } from "./commands/package.js";
 
 const program = new Command();
 
 program
-    .name('genesys-cli')
-    .description('G.E.N.E.S.Y.S CLI')
-    .version('1.0.0')
+  .name("genesys-cli")
+  .description("G.E.N.E.S.Y.S CLI")
+  .version("1.0.0");
+
+// Basic commands
+program
+  .command("make:node <name>")
+  .description("Generate a new Genesys node")
+  .action(makeNode);
 
 program
-    .command('make:node <name>')
-    .description('Generate a new Genesys node')
-    .action(makeNode);
+  .command("new <name>")
+  .description("Create a new Genesys project")
+  .action(newProject);
 
-program
-    .command('new <name>')
-    .description('Create a new Genesys project')
-    .action(newProject);
+// Add modular commands
+program.addCommand(launchCommand);
+program.addCommand(runCommand);
+program.addCommand(buildCommand);
+program.addCommand(simCommand);
+program.addCommand(testCommand);
+program.addCommand(configCommand);
+program.addCommand(recordCommand);
+program.addCommand(replayCommand);
+program.addCommand(packageCommand);
 
+// Parse CLI arguments
 program.parse(process.argv);

--- a/src/utils/launchUtils.ts
+++ b/src/utils/launchUtils.ts
@@ -1,0 +1,163 @@
+// src/utils/launchUtils.ts
+import { spawn } from "child_process";
+import path from "path";
+import fs from "fs";
+import chalk from "chalk";
+
+/* ----------------------------- Normalizers ----------------------------- */
+
+/**
+ * Normalize a launch file input.
+ * Accepts: "nav", "nav_launch", "nav_launch.py"
+ * Returns: "nav_launch.py"
+ */
+export function normalizeLaunchFile(input: string): string {
+  let file = input.trim();
+
+  if (!file.endsWith(".py") && !file.endsWith(".xml")) {
+    if (!file.endsWith("_launch")) file += "_launch";
+    file += ".py";
+  }
+
+  return file;
+}
+
+/* ----------------------------- Launch utils ----------------------------- */
+
+/**
+ * List all launch files in the workspace.
+ */
+export function listLaunchFiles(workspaceRoot: string): string[] {
+  const launchDir = path.join(workspaceRoot, "launch");
+  if (!fs.existsSync(launchDir)) return [];
+
+  return fs
+    .readdirSync(launchDir)
+    .filter(
+      (f) =>
+        f.endsWith("_launch.py") ||
+        f.endsWith(".launch.py") ||
+        f.endsWith(".launch.xml") ||
+        f === "genesys_launch.py"
+    );
+}
+
+/**
+ * Run a launch file from the workspace with optional ROS 2 launch arguments.
+ *
+ * @param workspaceRoot - Path to the workspace root
+ * @param fileName - Launch file name (absolute or relative to launch/)
+ * @param args - Optional array of launch arguments, e.g., ["world:=my_world.world"]
+ * @param rosDistro - ROS 2 distro to use (defaults to process.env.ROS_DISTRO or 'humble')
+ */
+export function runLaunchFile(
+  workspaceRoot: string,
+  fileName: string,
+  args: string[] = [],
+  rosDistro: string = process.env.ROS_DISTRO || "humble"
+) {
+  const launchDir = path.join(workspaceRoot, "launch");
+  const filePath = path.isAbsolute(fileName)
+    ? fileName
+    : path.join(launchDir, fileName);
+
+  if (!fs.existsSync(filePath)) {
+    console.error(chalk.red(`❌ Launch file not found: ${fileName}`));
+    process.exit(1);
+  }
+
+  const rosSetup = `/opt/ros/${rosDistro}/setup.bash`;
+  const argsString = args.join(" "); // convert args array to string
+
+  console.log(
+    chalk.cyan(
+      `🚀 Launching: ${chalk.green(filePath)} with ROS 2 '${rosDistro}'` +
+        (argsString ? ` and args: ${chalk.yellow(argsString)}` : "")
+    )
+  );
+
+  const proc = spawn(
+    "bash",
+    ["-c", `source ${rosSetup} && ros2 launch ${filePath} ${argsString}`],
+    { stdio: "inherit" }
+  );
+
+  proc.on("close", (code) => {
+    if (code === 0) console.log(chalk.green("✅ Launch completed successfully"));
+    else console.error(chalk.red(`❌ Launch exited with code ${code}`));
+  });
+
+  return proc;
+}
+
+
+/* ----------------------------- Node utils ----------------------------- */
+
+/**
+ * Spawn ros2 run process for a package executable.
+ */
+export function runNode(
+  packageName: string,
+  executable: string,
+  rosDistro: string = process.env.ROS_DISTRO || "humble"
+) {
+  const rosSetup = `/opt/ros/${rosDistro}/setup.bash`;
+
+  console.log(
+    chalk.cyan(`▶️ Running node: ${packageName}/${executable} with ROS 2 '${rosDistro}'`)
+  );
+
+  const proc = spawn("bash", ["-c", `source ${rosSetup} && ros2 run ${packageName} ${executable}`], {
+    stdio: "inherit",
+  });
+
+  proc.on("close", (code) => {
+    if (code === 0) console.log(chalk.green("✅ Node exited cleanly"));
+    else console.error(chalk.red(`❌ Node exited with code ${code}`));
+  });
+
+  return proc;
+}
+
+/**
+ * List available executables in packages under src/ and python/.
+ */
+export function listExecutables(workspaceRoot: string): Record<string, string[]> {
+  const pkgDirs = [path.join(workspaceRoot, "src"), path.join(workspaceRoot, "python")];
+  const executables: Record<string, string[]> = {};
+
+  pkgDirs.forEach((pkgDir) => {
+    if (!fs.existsSync(pkgDir)) return;
+
+    for (const pkg of fs.readdirSync(pkgDir)) {
+      const pkgPath = path.join(pkgDir, pkg);
+
+      // C++ package
+      if (fs.existsSync(path.join(pkgPath, "package.xml"))) {
+        const srcPath = path.join(pkgPath, "src");
+        if (fs.existsSync(srcPath)) {
+          const exeFiles = fs.readdirSync(srcPath).filter((f) => f.endsWith(".cpp"));
+          if (exeFiles.length > 0) {
+            executables[pkg] = exeFiles.map((f) => f.replace(".cpp", ""));
+          }
+        }
+      }
+
+      // Python package
+      else if (
+        fs.existsSync(path.join(pkgPath, "setup.py")) ||
+        fs.existsSync(path.join(pkgPath, "setup.cfg"))
+      ) {
+        const scriptsPath = path.join(pkgPath, "scripts");
+        if (fs.existsSync(scriptsPath)) {
+          const pyFiles = fs.readdirSync(scriptsPath).filter((f) => f.endsWith(".py"));
+          if (pyFiles.length > 0) {
+            executables[pkg] = pyFiles.map((f) => f.replace(".py", ""));
+          }
+        }
+      }
+    }
+  });
+
+  return executables;
+}


### PR DESCRIPTION
feat(cli): implement full Genesys CLI with core commands

- Updated project scaffolding commands: `new`, `make:node`, `package`
- Added workspace management commands: `build`, `launch`, `run`, `sim`
- Added testing commands: `test` (auto-detects Python/C++ packages and top-level tests)
- Added ROS 2 bag commands: `record` (records all topics by default), `replay` (defaults to latest bag)
- Added workspace config management: `config`
- Unified CLI entrypoint to register all commands
- Updated utilities for launch file normalization and arbitrary launch arguments
